### PR TITLE
Add option to simply specify a range of labels

### DIFF
--- a/panoptic_mapping/CMakeLists.txt
+++ b/panoptic_mapping/CMakeLists.txt
@@ -40,6 +40,7 @@ cs_add_library(${PROJECT_NAME}
         src/labels/label_handler_base.cpp
         src/labels/null_label_handler.cpp
         src/labels/csv_label_handler.cpp
+        src/labels/range_label_handler.cpp
         src/tracking/tracking_info.cpp
         src/tracking/single_tsdf_tracker.cpp
         src/tracking/ground_truth_id_tracker.cpp

--- a/panoptic_mapping/include/panoptic_mapping/labels/range_label_handler.h
+++ b/panoptic_mapping/include/panoptic_mapping/labels/range_label_handler.h
@@ -1,0 +1,43 @@
+#ifndef PANOPTIC_MAPPING_LABELS_RANGE_LABEL_HANDLER_H_
+#define PANOPTIC_MAPPING_LABELS_RANGE_LABEL_HANDLER_H_
+
+#include <string>
+
+#include "panoptic_mapping/3rd_party/config_utilities.hpp"
+#include "panoptic_mapping/common/common.h"
+#include "panoptic_mapping/labels/label_entry.h"
+#include "panoptic_mapping/labels/label_handler_base.h"
+
+namespace panoptic_mapping {
+
+/**
+ * @brief This label handler reads a csv file to get the labels.
+ */
+class RangeLabelHandler : public LabelHandlerBase {
+ public:
+  struct Config : public config_utilities::Config<Config> {
+    int verbosity = 4;
+
+    // Number of labels, initialises labels in range [0, num_labels - 1]
+    int num_labels;
+    Config() { setConfigName("RangeLabelHandler"); }
+
+   protected:
+    void setupParamsAndPrinting() override;
+    void checkParams() const override;
+  };
+
+  explicit RangeLabelHandler(const Config& config, bool print_config = true);
+  ~RangeLabelHandler() override = default;
+
+ private:
+  const Config config_;
+  static config_utilities::Factory::RegistrationRos<LabelHandlerBase,
+                                                    RangeLabelHandler>
+      registration_;
+  void initialiseLabels();
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_LABELS_RANGE_LABEL_HANDLER_H_

--- a/panoptic_mapping/include/panoptic_mapping/labels/range_label_handler.h
+++ b/panoptic_mapping/include/panoptic_mapping/labels/range_label_handler.h
@@ -11,7 +11,7 @@
 namespace panoptic_mapping {
 
 /**
- * @brief This label handler reads a csv file to get the labels.
+ * @brief This basic label handler allocates labels in an integer range.
  */
 class RangeLabelHandler : public LabelHandlerBase {
  public:

--- a/panoptic_mapping/src/labels/range_label_handler.cpp
+++ b/panoptic_mapping/src/labels/range_label_handler.cpp
@@ -1,0 +1,47 @@
+#include "panoptic_mapping/labels/range_label_handler.h"
+
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "panoptic_mapping/tools/coloring.h"
+
+namespace panoptic_mapping {
+
+config_utilities::Factory::RegistrationRos<LabelHandlerBase, RangeLabelHandler>
+    RangeLabelHandler::registration_("range");
+
+void RangeLabelHandler::Config::setupParamsAndPrinting() {
+  setupParam("verbosity", &verbosity);
+  setupParam("num_labels", &num_labels);
+}
+
+void RangeLabelHandler::Config::checkParams() const {
+  checkParamCond(num_labels >= 0, "num_labels must not be negative.");
+}
+
+RangeLabelHandler::RangeLabelHandler(const Config& config, bool print_config)
+    : config_(config.checkValid()) {
+  LOG_IF(INFO, config_.verbosity >= 1 && print_config) << "\n"
+                                                       << config_.toString();
+  // Setup the labels from range.
+  initialiseLabels();
+}
+
+void RangeLabelHandler::initialiseLabels() {
+  for (int i; i < config_.num_labels; i++) {
+    LabelEntry label;
+    label.segmentation_id = i;
+    label.class_id = i;
+    label.label = PanopticLabel::kBackground;
+    label.color = voxblox::rainbowColorMap(((float)i) / config_.num_labels);
+    labels_[i] = std::make_unique<LabelEntry>(label);
+  }
+
+  LOG_IF(INFO, config_.verbosity >= 1)
+      << "Created " << config_.num_labels << " labels.";
+}
+
+}  // namespace panoptic_mapping

--- a/panoptic_mapping/src/labels/range_label_handler.cpp
+++ b/panoptic_mapping/src/labels/range_label_handler.cpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "panoptic_mapping/tools/coloring.h"
-
 namespace panoptic_mapping {
 
 config_utilities::Factory::RegistrationRos<LabelHandlerBase, RangeLabelHandler>
@@ -19,7 +17,7 @@ void RangeLabelHandler::Config::setupParamsAndPrinting() {
 }
 
 void RangeLabelHandler::Config::checkParams() const {
-  checkParamCond(num_labels >= 0, "num_labels must not be negative.");
+  checkParamGT(num_labels, 0, "num_labels");
 }
 
 RangeLabelHandler::RangeLabelHandler(const Config& config, bool print_config)
@@ -39,9 +37,6 @@ void RangeLabelHandler::initialiseLabels() {
     label.color = voxblox::rainbowColorMap(((float)i) / config_.num_labels);
     labels_[i] = std::make_unique<LabelEntry>(label);
   }
-
-  LOG_IF(INFO, config_.verbosity >= 1)
-      << "Created " << config_.num_labels << " labels.";
 }
 
 }  // namespace panoptic_mapping

--- a/panoptic_mapping_ros/src/panoptic_mapper.cpp
+++ b/panoptic_mapping_ros/src/panoptic_mapper.cpp
@@ -92,8 +92,7 @@ void PanopticMapper::setupMembers() {
       config_utilities::FactoryRos::create<LabelHandlerBase>(
           defaultNh("label_handler"));
 
-  // Setup the number of labels. TODO(schmluk): there should be a more generic
-  // way to set the number of tracked labels based on the configuration.
+  // Setup the number of labels.
   FixedCountVoxel::setNumCounts(label_handler->numberOfLabels());
 
   // Globals.


### PR DESCRIPTION
Effectively solving this TODO https://github.com/ethz-asl/panoptic_mapping/blob/11b875e1f57c7e9f82545b04595a04433c4961f5/panoptic_mapping_ros/src/panoptic_mapper.cpp#L95 ;) 

works with such a config:

```yaml
labels:
  type: range
  num_labels: 40
```