### PR TITLE
Adds a score layer to track arbitrary floats per voxel

### DIFF
--- a/panoptic_mapping/CMakeLists.txt
+++ b/panoptic_mapping/CMakeLists.txt
@@ -37,6 +37,8 @@ cs_add_library(${PROJECT_NAME}
         src/map/classification/fixed_count.cpp
         src/map/classification/variable_count.cpp
         src/map/classification/uncertainty.cpp
+        src/map/scores/average.cpp
+        src/map/scores/latest.cpp
         src/labels/label_handler_base.cpp
         src/labels/null_label_handler.cpp
         src/labels/csv_label_handler.cpp

--- a/panoptic_mapping/include/panoptic_mapping/integration/class_projective_tsdf_integrator.h
+++ b/panoptic_mapping/include/panoptic_mapping/integration/class_projective_tsdf_integrator.h
@@ -56,7 +56,8 @@ class ClassProjectiveIntegrator : public ProjectiveIntegrator {
                    const Point& p_C, const InputData& input,
                    const int submap_id, const bool is_free_space_submap,
                    const float truncation_distance, const float voxel_size,
-                   ClassVoxel* class_voxel = nullptr) const override;
+                   ClassVoxel* class_voxel = nullptr,
+                   ScoreVoxel* score_voxel = nullptr) const override;
 
   void updateClassVoxel(InterpolatorBase* interpolator, ClassVoxel* voxel,
                         const InputData& input, const int submap_id) const;

--- a/panoptic_mapping/include/panoptic_mapping/integration/projection_interpolators.h
+++ b/panoptic_mapping/include/panoptic_mapping/integration/projection_interpolators.h
@@ -54,13 +54,21 @@ class InterpolatorBase {
    */
   virtual int interpolateID(const cv::Mat& id_image) = 0;
 
-    /**
+  /**
    * @brief Compute the uncertainty based on the internally cached weights.
    *
    * @param uncertainty_image Uncertainty Image image to interpolate in.
    * @return Color The interpolated uncertainty value.
    */
   virtual float interpolateUncertainty(const cv::Mat& uncertainty_image) = 0;
+
+  /**
+   * @brief Interpolate an image of floating point values.
+   *
+   * @param uncertainty_image image containing the values to interpolate in.
+   * @return The interpolated float value.
+   */
+  virtual float interpolateFloat(const cv::Mat& image) = 0;
 };
 
 /**
@@ -74,7 +82,8 @@ class InterpolatorNearest : public InterpolatorBase {
                       const Eigen::MatrixXf& range_image) override;
   float interpolateRange(const Eigen::MatrixXf& range_image) override;
   Color interpolateColor(const cv::Mat& color_image) override;
-  float interpolateUncertainty(const cv::Mat& uncertainty_image)  override;
+  float interpolateUncertainty(const cv::Mat& uncertainty_image) override;
+  float interpolateFloat(const cv::Mat& image) override;
   int interpolateID(const cv::Mat& id_image) override;
 
  protected:
@@ -97,8 +106,9 @@ class InterpolatorBilinear : public InterpolatorBase {
   void computeWeights(float u, float v,
                       const Eigen::MatrixXf& range_image) override;
   float interpolateRange(const Eigen::MatrixXf& range_image) override;
-  float interpolateUncertainty(const cv::Mat& uncertainty_image)  override;
+  float interpolateUncertainty(const cv::Mat& uncertainty_image) override;
   Color interpolateColor(const cv::Mat& color_image) override;
+  float interpolateFloat(const cv::Mat& image) override;
   int interpolateID(const cv::Mat& id_image) override;
 
  protected:
@@ -126,7 +136,8 @@ class InterpolatorAdaptive : public InterpolatorBilinear {
   float interpolateRange(const Eigen::MatrixXf& range_image) override;
   Color interpolateColor(const cv::Mat& color_image) override;
   int interpolateID(const cv::Mat& id_image) override;
-  float interpolateUncertainty(const cv::Mat& uncertainty_image)  override;
+  float interpolateFloat(const cv::Mat& image) override;
+  float interpolateUncertainty(const cv::Mat& uncertainty_image) override;
 
  protected:
   int u_;

--- a/panoptic_mapping/include/panoptic_mapping/integration/projective_tsdf_integrator.h
+++ b/panoptic_mapping/include/panoptic_mapping/integration/projective_tsdf_integrator.h
@@ -105,6 +105,7 @@ class ProjectiveIntegrator : public TsdfIntegratorBase {
    * @param truncation_distance Truncation distance to be used.
    * @param voxel_size Voxel size of the TSDF layer.
    * @param class_voxel Optional: class voxel to be updated.
+   * @param score_voxel Optional: score voxel to be updated.
 
    * @return True if the voxel was updated.
    */
@@ -113,7 +114,8 @@ class ProjectiveIntegrator : public TsdfIntegratorBase {
                            const int submap_id, const bool is_free_space_submap,
                            const float truncation_distance,
                            const float voxel_size,
-                           ClassVoxel* class_voxel = nullptr) const;
+                           ClassVoxel* class_voxel = nullptr,
+                           ScoreVoxel* score_voxel = nullptr) const;
 
   /**
    * @brief Sets up the interpolator and computes the signed distance.

--- a/panoptic_mapping/include/panoptic_mapping/integration/single_tsdf_integrator.h
+++ b/panoptic_mapping/include/panoptic_mapping/integration/single_tsdf_integrator.h
@@ -36,6 +36,9 @@ class SingleTsdfIntegrator : public ProjectiveIntegrator {
     // of type 'UncertaintyLayer'.
     bool use_uncertainty = false;
 
+    // If true require an uncertainty image and integrate it into a score layer.
+    bool use_score = false;
+
     // Decay rate in [0, 1] used to update uncertainty voxels. Only used if
     // 'use_uncertainty' is true.
     float uncertainty_decay_rate = 0.5f;
@@ -65,7 +68,8 @@ class SingleTsdfIntegrator : public ProjectiveIntegrator {
                    const Point& p_C, const InputData& input,
                    const int submap_id, const bool is_free_space_submap,
                    const float truncation_distance, const float voxel_size,
-                   ClassVoxel* class_voxel = nullptr) const override;
+                   ClassVoxel* class_voxel = nullptr,
+                   ScoreVoxel* score_voxel = nullptr) const override;
 
  private:
   const Config config_;
@@ -75,6 +79,8 @@ class SingleTsdfIntegrator : public ProjectiveIntegrator {
 
   void updateClassVoxel(InterpolatorBase* interpolator, const InputData& input,
                         ClassVoxel* class_voxel) const;
+  void updateScoreVoxel(InterpolatorBase* interpolator, const InputData& input,
+                        ScoreVoxel* score_voxel) const;
 
   void updateUncertaintyVoxel(InterpolatorBase* interpolator,
                               const InputData& input,

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/average.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/average.h
@@ -23,7 +23,7 @@ struct AverageScoreVoxel : public ScoreVoxel {
   ScoreVoxelType getVoxelType() const override;
   bool isObserverd() const override;
   float getScore() const override;
-  void addMeasurement(const float score, const float weight = 1.f) override;
+  void addMeasurement(const float score, const float weight = 1.0) override;
   bool mergeVoxel(const ScoreVoxel& other) override;
   std::vector<uint32_t> serializeVoxelToInt() const override;
   bool deseriliazeVoxelFromInt(const std::vector<uint32_t>& data,

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/average.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/average.h
@@ -1,0 +1,64 @@
+#ifndef PANOPTIC_MAPPING_MAP_SCORES_AVERAGE_H_
+#define PANOPTIC_MAPPING_MAP_SCORES_AVERAGE_H_
+
+#include <memory>
+#include <vector>
+
+#include "panoptic_mapping/3rd_party/config_utilities.hpp"
+#include "panoptic_mapping/Submap.pb.h"
+#include "panoptic_mapping/map/scores/score_layer_impl.h"
+#include "panoptic_mapping/map/scores/score_voxel.h"
+
+namespace panoptic_mapping {
+
+/**
+ * @brief Classification by counting the occurences of each label. The index 0
+ * is generally reserved for the belonging submap by shifting all IDs by 1. The
+ * memory for counting is lazily allocated since often only surface voxels are
+ * relevant.
+ */
+struct AverageScoreVoxel : public ScoreVoxel {
+ public:
+  // Implement interfaces.
+  ScoreVoxelType getVoxelType() const override;
+  bool isObserverd() const override;
+  float getScore() const override;
+  void addMeasurement(const float score, const float weight = 1.f) override;
+  bool mergeVoxel(const ScoreVoxel& other) override;
+  std::vector<uint32_t> serializeVoxelToInt() const override;
+  bool deseriliazeVoxelFromInt(const std::vector<uint32_t>& data,
+                               size_t* data_index) override;
+  // Data.
+  float accumulated_weight = 0;
+  float average_score;
+};
+
+class AverageScoreLayer : public ScoreLayerImpl<AverageScoreVoxel> {
+ public:
+  struct Config : public config_utilities::Config<Config> {
+    Config() { setConfigName("AverageScoreLayer"); }
+
+   protected:
+    void fromRosParam() override {}
+    void printFields() const override {}
+  };
+
+  AverageScoreLayer(const Config& config, const float voxel_size,
+                    const int voxels_per_side);
+
+  ScoreVoxelType getVoxelType() const override;
+  std::unique_ptr<ScoreLayer> clone() const override;
+  static std::unique_ptr<ScoreLayer> loadFromStream(
+      const SubmapProto& submap_proto, std::istream* /* proto_file_ptr */,
+      uint64_t* /* tmp_byte_offset_ptr */);
+
+ protected:
+  const Config config_;
+  static config_utilities::Factory::RegistrationRos<
+      ScoreLayer, AverageScoreLayer, float, int>
+      registration_;
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_MAP_SCORES_AVERAGE_H_

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/latest.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/latest.h
@@ -1,0 +1,64 @@
+#ifndef PANOPTIC_MAPPING_MAP_SCORES_LATEST_H_
+#define PANOPTIC_MAPPING_MAP_SCORES_LATEST_H_
+
+#include <memory>
+#include <vector>
+
+#include "panoptic_mapping/3rd_party/config_utilities.hpp"
+#include "panoptic_mapping/Submap.pb.h"
+#include "panoptic_mapping/map/scores/score_layer_impl.h"
+#include "panoptic_mapping/map/scores/score_voxel.h"
+
+namespace panoptic_mapping {
+
+/**
+ * @brief Classification by counting the occurences of each label. The index 0
+ * is generally reserved for the belonging submap by shifting all IDs by 1. The
+ * memory for counting is lazily allocated since often only surface voxels are
+ * relevant.
+ */
+struct LatestScoreVoxel : public ScoreVoxel {
+ public:
+  // Implement interfaces.
+  ScoreVoxelType getVoxelType() const override;
+  bool isObserverd() const override;
+  float getScore() const override;
+  void addMeasurement(const float score, const float weight = 1.f) override;
+  bool mergeVoxel(const ScoreVoxel& other) override;
+  std::vector<uint32_t> serializeVoxelToInt() const override;
+  bool deseriliazeVoxelFromInt(const std::vector<uint32_t>& data,
+                               size_t* data_index) override;
+  // Data.
+  float latest_score;
+  bool observed = false;
+};
+
+class LatestScoreLayer : public ScoreLayerImpl<LatestScoreVoxel> {
+ public:
+  struct Config : public config_utilities::Config<Config> {
+    Config() { setConfigName("LatestScoreLayer"); }
+
+   protected:
+    void fromRosParam() override {}
+    void printFields() const override {}
+  };
+
+  LatestScoreLayer(const Config& config, const float voxel_size,
+                    const int voxels_per_side);
+
+  ScoreVoxelType getVoxelType() const override;
+  std::unique_ptr<ScoreLayer> clone() const override;
+  static std::unique_ptr<ScoreLayer> loadFromStream(
+      const SubmapProto& submap_proto, std::istream* /* proto_file_ptr */,
+      uint64_t* /* tmp_byte_offset_ptr */);
+
+ protected:
+  const Config config_;
+  static config_utilities::Factory::RegistrationRos<
+      ScoreLayer, LatestScoreLayer, float, int>
+      registration_;
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_MAP_SCORES_LATEST_H_

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/latest.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/latest.h
@@ -23,14 +23,13 @@ struct LatestScoreVoxel : public ScoreVoxel {
   ScoreVoxelType getVoxelType() const override;
   bool isObserverd() const override;
   float getScore() const override;
-  void addMeasurement(const float score, const float weight = 1.f) override;
+  void addMeasurement(const float score, const float weight = 1.0) override;
   bool mergeVoxel(const ScoreVoxel& other) override;
   std::vector<uint32_t> serializeVoxelToInt() const override;
   bool deseriliazeVoxelFromInt(const std::vector<uint32_t>& data,
                                size_t* data_index) override;
   // Data.
-  float latest_score;
-  bool observed = false;
+  float latest_score = NAN;
 };
 
 class LatestScoreLayer : public ScoreLayerImpl<LatestScoreVoxel> {

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/score_block.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/score_block.h
@@ -1,0 +1,123 @@
+#ifndef PANOPTIC_MAPPING_MAP_SCORES_SCORE_BLOCK_H_
+#define PANOPTIC_MAPPING_MAP_SCORES_SCORE_BLOCK_H_
+
+#include <memory>
+#include <utility>
+
+#include <voxblox/core/block.h>
+
+#include "panoptic_mapping/common/common.h"
+#include "panoptic_mapping/map/scores/score_voxel.h"
+
+namespace panoptic_mapping {
+
+/**
+ * @brief General interface for score voxel blocks. Wraps the voxblox
+ * block to allow substituting different classification layer types.
+ */
+class ScoreBlock {
+ public:
+  // Wrap the shared pointer operator bool to account for the wrapped blocks.
+  class Ptr : public std::shared_ptr<ScoreBlock> {
+   public:
+    explicit Ptr(ScoreBlock* ptr = nullptr)
+        : std::shared_ptr<ScoreBlock>(ptr) {}
+    operator bool() const {
+      if (!std::shared_ptr<ScoreBlock>::operator bool()) {
+        return false;
+      }
+      return this->operator->()->isValid();
+    }
+  };
+  class ConstPtr : public std::shared_ptr<const ScoreBlock> {
+   public:
+    explicit ConstPtr(const ScoreBlock* ptr = nullptr)
+        : std::shared_ptr<const ScoreBlock>(ptr) {}
+    operator bool() const {
+      if (!std::shared_ptr<const ScoreBlock>::operator bool()) {
+        return false;
+      }
+      return this->operator->()->isValid();
+    }
+  };
+
+  virtual ~ScoreBlock() = default;
+
+  // Implements all voxel access interfaces.
+  virtual const ScoreVoxel& getVoxelByLinearIndex(size_t index) const = 0;
+  virtual const ScoreVoxel& getVoxelByVoxelIndex(
+      const VoxelIndex& index) const = 0;
+  virtual const ScoreVoxel& getVoxelByCoordinates(
+      const Point& coords) const = 0;
+  virtual ScoreVoxel& getVoxelByCoordinates(const Point& coords) = 0;
+  virtual ScoreVoxel* getVoxelPtrByCoordinates(const Point& coords) = 0;
+  virtual const ScoreVoxel* getVoxelPtrByCoordinates(
+      const Point& coords) const = 0;
+  virtual ScoreVoxel& getVoxelByLinearIndex(size_t index) = 0;
+  virtual ScoreVoxel& getVoxelByVoxelIndex(const VoxelIndex& index) = 0;
+  virtual ScoreVoxelType getVoxelType() const = 0;
+
+  // Additional checks for validity.
+  operator bool() const { return isValid(); }
+
+ protected:
+  virtual bool isValid() const = 0;
+};
+
+/**
+ * @brief Implements all the interface fucntions to wrap a block of VoxelT
+ * voxels.
+ *
+ * @tparam VoxelT Voxel type contained in the wrapped block. Needs to inherit
+ * from ScoreVoxel.
+ */
+template <typename VoxelT>
+class ScoreBlockImpl : public ScoreBlock {
+ public:
+  explicit ScoreBlockImpl(
+      std::shared_ptr<voxblox::Block<VoxelT>> block = nullptr)
+      : block_(std::move(block)) {}
+
+  const ScoreVoxel& getVoxelByLinearIndex(size_t index) const override {
+    return block_->getVoxelByLinearIndex(index);
+  }
+  const ScoreVoxel& getVoxelByVoxelIndex(
+      const VoxelIndex& index) const override {
+    return block_->getVoxelByVoxelIndex(index);
+  }
+  const ScoreVoxel& getVoxelByCoordinates(const Point& coords) const override {
+    return block_->getVoxelByCoordinates(coords);
+  }
+  ScoreVoxel& getVoxelByCoordinates(const Point& coords) override {
+    return block_->getVoxelByCoordinates(coords);
+  }
+  ScoreVoxel* getVoxelPtrByCoordinates(const Point& coords) override {
+    return block_->getVoxelPtrByCoordinates(coords);
+  }
+  const ScoreVoxel* getVoxelPtrByCoordinates(
+      const Point& coords) const override {
+    return block_->getVoxelPtrByCoordinates(coords);
+  }
+  ScoreVoxel& getVoxelByLinearIndex(size_t index) override {
+    return block_->getVoxelByLinearIndex(index);
+  }
+  ScoreVoxel& getVoxelByVoxelIndex(const VoxelIndex& index) override {
+    return block_->getVoxelByVoxelIndex(index);
+  }
+  ScoreVoxelType getVoxelType() const override {
+    return reinterpret_cast<const ScoreVoxel&>(block_->getVoxelByLinearIndex(0))
+        .getVoxelType();
+  }
+
+  // Exposes the actual block if the type is known.
+  voxblox::Block<VoxelT>& getBlock() { return *block_; }
+  const voxblox::Block<VoxelT>& getBlock() const { return *block_; }
+
+ protected:
+  const std::shared_ptr<voxblox::Block<VoxelT>> block_;
+  bool isValid() const override { return block_.operator bool(); }
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_MAP_SCORES_SCORE_BLOCK_H_

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/score_layer.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/score_layer.h
@@ -1,0 +1,74 @@
+#ifndef PANOPTIC_MAPPING_MAP_SCORES_SCORE_LAYER_H_
+#define PANOPTIC_MAPPING_MAP_SCORES_SCORE_LAYER_H_
+
+#include <memory>
+#include <utility>
+
+#include <voxblox/core/layer.h>
+
+#include "panoptic_mapping/common/common.h"
+#include "panoptic_mapping/map/scores/score_block.h"
+#include "panoptic_mapping/map/scores/score_voxel.h"
+
+namespace panoptic_mapping {
+
+/**
+ * @brief General interface to score voxel layers. Wraps the voxblox
+ * layer to allow substituting different score layer types.
+ */
+class ScoreLayer {
+ public:
+  virtual ~ScoreLayer() = default;
+
+  // Implement this to expose the voxel type to objects that use a specific
+  // voxel type.
+  virtual ScoreVoxelType getVoxelType() const = 0;
+
+  // Voxblox interfaces.
+  virtual ScoreBlock::ConstPtr getBlockConstPtrByIndex(
+      const BlockIndex& index) const = 0;
+  virtual ScoreBlock::Ptr getBlockPtrByIndex(const BlockIndex& index) = 0;
+  virtual ScoreBlock::Ptr allocateBlockPtrByIndex(const BlockIndex& index) = 0;
+  virtual ScoreBlock::ConstPtr getBlockPtrByCoordinates(
+      const Point& coords) const = 0;
+  virtual ScoreBlock::Ptr getBlockPtrByCoordinates(const Point& coords) = 0;
+  virtual ScoreBlock::Ptr allocateBlockPtrByCoordinates(
+      const Point& coords) = 0;
+  virtual ScoreBlock::Ptr allocateNewBlock(const BlockIndex& index) = 0;
+  virtual ScoreBlock::Ptr allocateNewBlockByCoordinates(
+      const Point& coords) = 0;
+  virtual void removeBlock(const BlockIndex& index) = 0;
+  virtual void removeAllBlocks() = 0;
+  virtual void removeBlockByCoordinates(const Point& coords) = 0;
+  virtual void getAllAllocatedBlocks(voxblox::BlockIndexList* blocks) const = 0;
+  virtual void getAllUpdatedBlocks(voxblox::Update::Status bit,
+                                   voxblox::BlockIndexList* blocks) const = 0;
+  virtual size_t getNumberOfAllocatedBlocks() const = 0;
+  virtual bool hasBlock(const BlockIndex& block_index) const = 0;
+  virtual size_t getMemorySize() const = 0;
+  virtual size_t voxels_per_side() const = 0;
+  virtual FloatingPoint voxel_size() const = 0;
+  virtual FloatingPoint block_size() const = 0;
+  virtual std::unique_ptr<ScoreLayer> clone() const = 0;
+
+  // Serialization
+  virtual bool saveBlockToStream(BlockIndex block_index,
+                                 std::fstream* outfile_ptr) const = 0;
+  virtual bool saveBlocksToStream(bool include_all_blocks,
+                                  voxblox::BlockIndexList blocks_to_include,
+                                  std::fstream* outfile_ptr) const = 0;
+  virtual bool addBlockFromProto(const voxblox::BlockProto& block_proto) = 0;
+
+  /**
+   * @brief Directly returns the voxel if it exists. Returns nullpointer
+   * otherwise. Prefer this when looking up sparse voxels since it avoids the
+   * ScoreBlock intermediate step.
+   */
+  virtual ScoreVoxel* getVoxelPtrByCoordinates(const Point& coords) = 0;
+  virtual const ScoreVoxel* getVoxelPtrByCoordinates(
+      const Point& coords) const = 0;
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_MAP_SCORES_SCORE_LAYER_H_

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/score_layer_impl.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/score_layer_impl.h
@@ -1,0 +1,207 @@
+#ifndef PANOPTIC_MAPPING_MAP_SCORES_SCORE_LAYER_IMPL_H_
+#define PANOPTIC_MAPPING_MAP_SCORES_SCORE_LAYER_IMPL_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <voxblox/core/layer.h>
+
+#include "panoptic_mapping/common/common.h"
+#include "panoptic_mapping/map/scores/score_block.h"
+#include "panoptic_mapping/map/scores/score_voxel.h"
+#include "panoptic_mapping/tools/serialization.h"
+
+namespace panoptic_mapping {
+
+/**
+ * @brief Default implementation for the class layer wrapper which implements
+ * the shared set of functionalities (voxblox interfaces and serialization).
+ *
+ * @tparam VoxelT Voxel type to be stored in this layer.
+ */
+template <typename VoxelT>
+class ScoreLayerImpl : public ScoreLayer {
+ public:
+  explicit ScoreLayerImpl<VoxelT>(voxblox::FloatingPoint voxel_size,
+                                  size_t voxels_per_side)
+      : layer_(voxel_size, voxels_per_side) {}
+
+  // Block access interfaces.
+  ScoreBlock::ConstPtr getBlockConstPtrByIndex(
+      const BlockIndex& index) const override {
+    return getScoreBlockConstPtr(layer_.getBlockPtrByIndex(index));
+  }
+  ScoreBlock::Ptr getBlockPtrByIndex(const BlockIndex& index) override {
+    return getScoreBlockPtr(layer_.getBlockPtrByIndex(index));
+  }
+  ScoreBlock::Ptr allocateBlockPtrByIndex(const BlockIndex& index) override {
+    return getScoreBlockPtr(layer_.allocateBlockPtrByIndex(index));
+  }
+  ScoreBlock::ConstPtr getBlockPtrByCoordinates(
+      const Point& coords) const override {
+    return getScoreBlockConstPtr(layer_.getBlockPtrByCoordinates(coords));
+  }
+  ScoreBlock::Ptr getBlockPtrByCoordinates(const Point& coords) override {
+    return getScoreBlockPtr(layer_.getBlockPtrByCoordinates(coords));
+  }
+  ScoreBlock::Ptr allocateBlockPtrByCoordinates(const Point& coords) override {
+    return getScoreBlockPtr(layer_.allocateBlockPtrByCoordinates(coords));
+  }
+  ScoreBlock::Ptr allocateNewBlock(const BlockIndex& index) override {
+    return getScoreBlockPtr(layer_.allocateNewBlock(index));
+  }
+  ScoreBlock::Ptr allocateNewBlockByCoordinates(const Point& coords) override {
+    return getScoreBlockPtr(layer_.allocateNewBlockByCoordinates(coords));
+  }
+
+  // General functions.
+  void removeBlock(const BlockIndex& index) override {
+    layer_.removeBlock(index);
+  }
+  void removeAllBlocks() override { layer_.removeAllBlocks(); }
+  void removeBlockByCoordinates(const Point& coords) override {
+    layer_.removeBlockByCoordinates(coords);
+  }
+  void getAllAllocatedBlocks(voxblox::BlockIndexList* blocks) const override {
+    layer_.getAllAllocatedBlocks(blocks);
+  }
+  void getAllUpdatedBlocks(voxblox::Update::Status bit,
+                           voxblox::BlockIndexList* blocks) const override {
+    layer_.getAllUpdatedBlocks(bit, blocks);
+  }
+  size_t getNumberOfAllocatedBlocks() const override {
+    return layer_.getNumberOfAllocatedBlocks();
+  }
+  bool hasBlock(const BlockIndex& block_index) const override {
+    return layer_.hasBlock(block_index);
+  }
+
+  size_t getMemorySize() const override { return layer_.getMemorySize(); }
+  size_t voxels_per_side() const override { return layer_.voxels_per_side(); }
+  FloatingPoint voxel_size() const override { return layer_.voxel_size(); }
+  FloatingPoint block_size() const override { return layer_.block_size(); }
+
+  // Serialization.
+  bool saveBlockToStream(BlockIndex block_index,
+                         std::fstream* outfile_ptr) const override {
+    CHECK_NOTNULL(outfile_ptr);
+    auto block = layer_.getBlockPtrByIndex(block_index);
+    if (!block) {
+      return false;
+    }
+
+    // Save data.
+    voxblox::BlockProto proto;
+    proto.set_has_data(block->has_data());
+    proto.set_voxels_per_side(block->voxels_per_side());
+    proto.set_voxel_size(block->voxel_size());
+    proto.set_origin_x(block->origin().x());
+    proto.set_origin_y(block->origin().y());
+    proto.set_origin_z(block->origin().z());
+    for (size_t i = 0; i < block->num_voxels(); ++i) {
+      for (uint32_t word :
+           reinterpret_cast<const ScoreVoxel&>(block->getVoxelByLinearIndex(i))
+               .serializeVoxelToInt()) {
+        proto.add_voxel_data(word);
+      }
+    }
+    if (!voxblox::utils::writeProtoMsgToStream(proto, outfile_ptr)) {
+      LOG(ERROR) << "Could not write score block proto message to stream.";
+      return false;
+    }
+    return true;
+  }
+
+  bool saveBlocksToStream(bool include_all_blocks,
+                          voxblox::BlockIndexList blocks_to_include,
+                          std::fstream* outfile_ptr) const override {
+    CHECK_NOTNULL(outfile_ptr);
+    // Get blocks to write.
+    if (include_all_blocks) {
+      layer_.getAllAllocatedBlocks(&blocks_to_include);
+    }
+
+    // Write blocks.
+    for (const BlockIndex& index : blocks_to_include) {
+      if (!saveBlockToStream(index, outfile_ptr)) {
+        LOG(WARNING) << "Could not save block " << index.transpose()
+                     << " to stream.";
+      }
+    }
+    return true;
+  }
+
+  bool addBlockFromProto(const voxblox::BlockProto& block_proto) override {
+    // Check compatibility.
+    if (!isCompatible(block_proto, *this)) {
+      return false;
+    }
+
+    // Add (potentially replace) the block.
+    const Point origin(block_proto.origin_x(), block_proto.origin_y(),
+                       block_proto.origin_z());
+    layer_.removeBlockByCoordinates(origin);
+    auto block = layer_.allocateNewBlockByCoordinates(origin);
+
+    // Read the data.
+    std::vector<uint32_t> data;
+    data.resize(block_proto.voxel_data_size());
+    size_t index = 0;
+    for (uint32_t word : block_proto.voxel_data()) {
+      data[index] = word;
+      index++;
+    }
+
+    // Load the voxels.
+    index = 0;
+    for (size_t i = 0; i < block->num_voxels(); ++i) {
+      if (!reinterpret_cast<ScoreVoxel&>(block->getVoxelByLinearIndex(i))
+               .deseriliazeVoxelFromInt(data, &index)) {
+        LOG(WARNING) << "Could not serialize voxel from data.";
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Lookup.
+  ScoreVoxel* getVoxelPtrByCoordinates(const Point& coords) override {
+    return layer_.getVoxelPtrByCoordinates(coords);
+  }
+  const ScoreVoxel* getVoxelPtrByCoordinates(
+      const Point& coords) const override {
+    return layer_.getVoxelPtrByCoordinates(coords);
+  }
+
+  // Exposes the layer block if the type is known.
+  voxblox::Layer<VoxelT>& getLayer() { return layer_; }
+  const voxblox::Layer<VoxelT>& getLayer() const { return layer_; }
+
+ protected:
+  voxblox::Layer<VoxelT> layer_;
+
+  // Common conversion functions for the class block wrapper.
+  ScoreBlock::Ptr getScoreBlockPtr(
+      const typename voxblox::Block<VoxelT>::Ptr& block_ptr) {
+    if (block_ptr) {
+      return ScoreBlock::Ptr(new ScoreBlockImpl<VoxelT>(block_ptr));
+    }
+    return ScoreBlock::Ptr();
+  }
+  ScoreBlock::ConstPtr getScoreBlockConstPtr(
+      const typename voxblox::Block<VoxelT>::ConstPtr& block_ptr) const {
+    // NOTE(schmluk): Since const pointers are returned the const-ness is cast
+    // away to create the ScoreBlock Wrapper. The block itself should thus
+    // still be protected.
+    if (block_ptr) {
+      return ScoreBlock::ConstPtr(new ScoreBlockImpl<VoxelT>(
+          std::const_pointer_cast<voxblox::Block<VoxelT>>(block_ptr)));
+    }
+    return ScoreBlock::ConstPtr();
+  }
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_MAP_SCORES_SCORE_LAYER_IMPL_H_

--- a/panoptic_mapping/include/panoptic_mapping/map/scores/score_voxel.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/scores/score_voxel.h
@@ -1,0 +1,81 @@
+#ifndef PANOPTIC_MAPPING_MAP_SCORES_SCORE_VOXEL_H_
+#define PANOPTIC_MAPPING_MAP_SCORES_SCORE_VOXEL_H_
+
+#include <vector>
+
+namespace panoptic_mapping {
+
+// Enumerate all implemented classification voxel types for objects that need to
+// operate on specific voxel types.
+enum class ScoreVoxelType {
+  kLatest,
+  kAverage,
+};
+
+/**
+ * @brief General interface for voxels that aggregate a floating point number,
+ * e.g. an uncertainty, novelty score or the likes.
+ */
+struct ScoreVoxel {
+  virtual ~ScoreVoxel() = default;
+
+  /**
+   * @brief Expose the contained type of the voxel for objects that need to
+   * operate on specific voxel types.
+   */
+  virtual ScoreVoxelType getVoxelType() const = 0;
+
+  /**
+   * @brief Return true if the voxel has received any measurements yet.
+   */
+  virtual bool isObserverd() const = 0;
+
+  /**
+   * @brief Return the current score value in the voxel.
+   * @return float The score.
+   */
+  virtual float getScore() const = 0;
+
+  /**
+   * @brief Add a measurement to this voxel that will be aggregated dependent on
+   * the specified voxel type.
+   *
+   * @param float The measurement.
+   * @param weight Optional. The weight by which this measurement is weighted in
+   * the aggregation scheme.
+   */
+  virtual void addMeasurement(const float score, const float weight = 1.f) = 0;
+
+  /**
+   * @brief Merge another voxel into this voxel. If the default merging
+   * behavior is not desired, the voxel members are exposed to custom
+   * manipulation.
+   *
+   * @param other Voxel to merge into this one.
+   * @return True if the merging was successful.
+   */
+  virtual bool mergeVoxel(const ScoreVoxel& other) = 0;
+
+  /**
+   * @brief Serialization tool to serialize voxels and layers to integer data.
+   *
+   * @param data The current binary data to append the voxel to.
+   */
+  virtual std::vector<uint32_t> serializeVoxelToInt() const = 0;
+
+  /**
+   * @brief De-serialize the voxel from integer data.
+   *
+   * @param data The data to read from.
+   * @param data_index Index from where to read the data. This index should be
+   * updated to point to the end of the serialized data such that the next voxel
+   * can be read from there.
+   * @return True if the voxel was correctly de-serialized, false otherwise.
+   */
+  virtual bool deseriliazeVoxelFromInt(const std::vector<uint32_t>& data,
+                                       size_t* data_index) = 0;
+};
+
+}  // namespace panoptic_mapping
+
+#endif  // PANOPTIC_MAPPING_MAP_SCORES_SCORE_VOXEL_H_

--- a/panoptic_mapping/include/panoptic_mapping/map/submap.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/submap.h
@@ -18,6 +18,9 @@
 #include "panoptic_mapping/map/classification/class_block.h"
 #include "panoptic_mapping/map/classification/class_layer.h"
 #include "panoptic_mapping/map/classification/class_voxel.h"
+#include "panoptic_mapping/map/scores/score_block.h"
+#include "panoptic_mapping/map/scores/score_layer.h"
+#include "panoptic_mapping/map/scores/score_voxel.h"
 #include "panoptic_mapping/map/instance_id.h"
 #include "panoptic_mapping/map/submap_bounding_volume.h"
 #include "panoptic_mapping/map/submap_id.h"
@@ -44,6 +47,11 @@ class Submap {
     // classification.
     config_utilities::VariableConfig<ClassLayer> classification;
 
+    // Config of the classification voxels to be used. Leave the config
+    // uninitialized (not setting the 'type' param) can be used to not use any
+    // classification.
+    config_utilities::VariableConfig<ScoreLayer> scores;
+
     // Config of the mesh integrator.
     MeshIntegrator::Config mesh;
 
@@ -51,6 +59,8 @@ class Submap {
 
     // Utility tool that checks whether a classification layer was specified.
     bool useClassLayer() const;
+    // Utility tool that checks whether a score layer was specified.
+    bool useScoreLayer() const;
 
    protected:
     void setupParamsAndPrinting() override;
@@ -76,12 +86,14 @@ class Submap {
   const std::string& getFrameName() const { return frame_name_; }
   const TsdfLayer& getTsdfLayer() const { return *tsdf_layer_; }
   const ClassLayer& getClassLayer() const { return *class_layer_; }
+  const ScoreLayer& getScoreLayer() const { return *score_layer_; }
   const voxblox::MeshLayer& getMeshLayer() const { return *mesh_layer_; }
   const Transformation& getT_M_S() const { return T_M_S_; }
   const Transformation& getT_S_M() const { return T_M_S_inv_; }
   bool isActive() const { return is_active_; }
   bool wasTracked() const { return was_tracked_; }
   bool hasClassLayer() const { return has_class_layer_; }
+  bool hasScoreLayer() const { return has_score_layer_; }
   const std::vector<IsoSurfacePoint>& getIsoSurfacePoints() const {
     return iso_surface_points_;
   }
@@ -93,6 +105,7 @@ class Submap {
   // Modifying accessors.
   std::shared_ptr<TsdfLayer>& getTsdfLayerPtr() { return tsdf_layer_; }
   std::shared_ptr<ClassLayer>& getClassLayerPtr() { return class_layer_; }
+  std::shared_ptr<ScoreLayer>& getScoreLayerPtr() { return score_layer_; }
   std::shared_ptr<voxblox::MeshLayer>& getMeshLayerPtr() { return mesh_layer_; }
   std::vector<IsoSurfacePoint>* getIsoSurfacePointsPtr() {
     return &iso_surface_points_;
@@ -236,6 +249,7 @@ class Submap {
   bool is_active_ = true;
   bool was_tracked_ = true;  // Set to true by the id tracker if matched.
   bool has_class_layer_ = false;
+  bool has_score_layer_ = false;
   ChangeState change_state_ = ChangeState::kNew;
 
   // Transformations.
@@ -246,6 +260,7 @@ class Submap {
   // Map.
   std::shared_ptr<TsdfLayer> tsdf_layer_;
   std::shared_ptr<ClassLayer> class_layer_;
+  std::shared_ptr<ScoreLayer> score_layer_;
   std::shared_ptr<voxblox::MeshLayer> mesh_layer_;
   std::vector<IsoSurfacePoint> iso_surface_points_;
   SubmapBoundingVolume bounding_volume_;

--- a/panoptic_mapping/include/panoptic_mapping/map/submap.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/submap.h
@@ -48,9 +48,9 @@ class Submap {
     // classification.
     config_utilities::VariableConfig<ClassLayer> classification;
 
-    // Config of the classification voxels to be used. Leave the config
+    // Config of the score voxels to be used. Leave the config
     // uninitialized (not setting the 'type' param) can be used to not use any
-    // classification.
+    // score integration.
     config_utilities::VariableConfig<ScoreLayer> scores;
 
     // Config of the mesh integrator.

--- a/panoptic_mapping/include/panoptic_mapping/map/submap.h
+++ b/panoptic_mapping/include/panoptic_mapping/map/submap.h
@@ -32,6 +32,7 @@ class LayerManipulator;
 class Submap {
  public:
   struct Config : public config_utilities::Config<Config> {
+    int verbosity = 1;
     // Size of one voxel in meters.
     float voxel_size = 0.1;
 

--- a/panoptic_mapping/include/panoptic_mapping/test/comparison_utils.h
+++ b/panoptic_mapping/include/panoptic_mapping/test/comparison_utils.h
@@ -10,6 +10,8 @@
 #include "panoptic_mapping/map/classification/moving_binary_count.h"
 #include "panoptic_mapping/map/classification/uncertainty.h"
 #include "panoptic_mapping/map/classification/variable_count.h"
+#include "panoptic_mapping/map/scores/average.h"
+#include "panoptic_mapping/map/scores/latest.h"
 
 namespace panoptic_mapping {
 namespace test {
@@ -98,6 +100,20 @@ inline bool checkVoxelEqual(const UncertaintyVoxel& v1,
   EXPECT_EQ(v1.uncertainty, v2.uncertainty);
   return v1.is_ground_truth == v2.is_ground_truth &&
          v1.uncertainty == v2.uncertainty;
+}
+
+inline bool checkVoxelEqual(const AverageScoreVoxel& v1,
+                            const AverageScoreVoxel& v2) {
+  EXPECT_EQ(v1.average_score, v2.average_score);
+  EXPECT_EQ(v1.accumulated_weight, v2.accumulated_weight);
+  return v1.average_score == v2.average_score &&
+         v1.accumulated_weight == v2.accumulated_weight;
+}
+
+inline bool checkVoxelEqual(const LatestScoreVoxel& v1,
+                            const LatestScoreVoxel& v2) {
+  EXPECT_EQ(v1.latest_score, v2.latest_score);
+  return v1.latest_score == v2.latest_score;
 }
 
 template <typename T>

--- a/panoptic_mapping/include/panoptic_mapping/test/randomization_utils.h
+++ b/panoptic_mapping/include/panoptic_mapping/test/randomization_utils.h
@@ -10,6 +10,8 @@
 #include "panoptic_mapping/map/classification/moving_binary_count.h"
 #include "panoptic_mapping/map/classification/uncertainty.h"
 #include "panoptic_mapping/map/classification/variable_count.h"
+#include "panoptic_mapping/map/scores/average.h"
+#include "panoptic_mapping/map/scores/latest.h"
 
 namespace panoptic_mapping {
 namespace test {
@@ -91,6 +93,15 @@ void randomizeVoxel(UncertaintyVoxel* voxel) {
   randomizeVoxel(static_cast<FixedCountVoxel*>(voxel));
   voxel->is_ground_truth = getRandomInt(0, 1);
   voxel->uncertainty = getRandomReal<float>();
+}
+
+void randomizeVoxel(AverageScoreVoxel* voxel) {
+  voxel->accumulated_weight = getRandomReal<float>(0);
+  voxel->average_score = getRandomReal<float>();
+}
+
+void randomizeVoxel(LatestScoreVoxel* voxel) {
+  voxel->latest_score = getRandomReal<float>();
 }
 
 }  // namespace test

--- a/panoptic_mapping/include/panoptic_mapping/tools/serialization.h
+++ b/panoptic_mapping/include/panoptic_mapping/tools/serialization.h
@@ -9,6 +9,7 @@
 #include "panoptic_mapping/Submap.pb.h"
 #include "panoptic_mapping/common/common.h"
 #include "panoptic_mapping/map/classification/class_layer.h"
+#include "panoptic_mapping/map/scores/score_layer.h"
 #include "panoptic_mapping/map/submap.h"
 
 namespace panoptic_mapping {
@@ -73,6 +74,19 @@ bool loadClassBlocksFromStream(const SubmapProto& submap_proto,
 bool isCompatible(const voxblox::BlockProto& block_proto,
                   const ClassLayer& layer);
 
+std::unique_ptr<ScoreLayer> loadScoreLayerFromStream(
+    const SubmapProto& submap_proto, std::istream* proto_file_ptr,
+    uint64_t* tmp_byte_offset_ptr);
+
+bool saveScoreLayerToStream(const ScoreLayer& layer);
+
+bool loadScoreBlocksFromStream(const SubmapProto& submap_proto,
+                               std::istream* proto_file_ptr,
+                               uint64_t* tmp_byte_offset_ptr,
+                               ScoreLayer* layer);
+
+bool isCompatible(const voxblox::BlockProto& block_proto,
+                  const ScoreLayer& layer);
 }  // namespace panoptic_mapping
 
 #endif  // PANOPTIC_MAPPING_TOOLS_SERIALIZATION_H_

--- a/panoptic_mapping/proto/panoptic_mapping/Submap.proto
+++ b/panoptic_mapping/proto/panoptic_mapping/Submap.proto
@@ -22,7 +22,7 @@ message SubmapProto {
   optional uint32 num_class_blocks = 12;
   optional int32 class_voxel_type = 13;
 
-  // Classification Layer.
+  // Score Layer.
   optional uint32 num_score_blocks = 14;
   optional int32 score_voxel_type = 15;
 

--- a/panoptic_mapping/proto/panoptic_mapping/Submap.proto
+++ b/panoptic_mapping/proto/panoptic_mapping/Submap.proto
@@ -22,6 +22,10 @@ message SubmapProto {
   optional uint32 num_class_blocks = 12;
   optional int32 class_voxel_type = 13;
 
+  // Classification Layer.
+  optional uint32 num_score_blocks = 14;
+  optional int32 score_voxel_type = 15;
+
   // Submap Transformation.
   optional cblox.QuatTransformationProto transform = 5;
   optional string frame_name = 10;

--- a/panoptic_mapping/src/integration/class_projective_tsdf_integrator.cpp
+++ b/panoptic_mapping/src/integration/class_projective_tsdf_integrator.cpp
@@ -118,7 +118,8 @@ bool ClassProjectiveIntegrator::updateVoxel(
     InterpolatorBase* interpolator, TsdfVoxel* voxel, const Point& p_C,
     const InputData& input, const int submap_id,
     const bool is_free_space_submap, const float truncation_distance,
-    const float voxel_size, ClassVoxel* class_voxel) const {
+    const float voxel_size, ClassVoxel* class_voxel,
+    ScoreVoxel* score_voxel) const {
   // Compute the signed distance. This also sets up the interpolator.
   float sdf;
   if (!computeSignedDistance(p_C, interpolator, &sdf)) {

--- a/panoptic_mapping/src/integration/projection_interpolators.cpp
+++ b/panoptic_mapping/src/integration/projection_interpolators.cpp
@@ -19,8 +19,13 @@ void InterpolatorNearest::computeWeights(float u, float v,
   v_ = std::round(v);
 }
 
-float InterpolatorNearest::interpolateUncertainty(const cv::Mat &uncertainty_image) {
+float InterpolatorNearest::interpolateUncertainty(
+    const cv::Mat& uncertainty_image) {
   return uncertainty_image.at<float>(v_, u_);
+}
+
+float InterpolatorNearest::interpolateFloat(const cv::Mat& image) {
+  return image.at<float>(v_, u_);
 }
 
 float InterpolatorNearest::interpolateRange(
@@ -57,11 +62,19 @@ float InterpolatorBilinear::interpolateRange(
          range_image(v_ + 1, u_ + 1) * weight_[3];
 }
 
-float InterpolatorBilinear::interpolateUncertainty(const cv::Mat &uncertainty_image) {
+float InterpolatorBilinear::interpolateUncertainty(
+    const cv::Mat& uncertainty_image) {
   return uncertainty_image.at<float>(v_, u_) * weight_[0] +
          uncertainty_image.at<float>(v_ + 1, u_) * weight_[1] +
          uncertainty_image.at<float>(v_, u_ + 1) * weight_[2] +
          uncertainty_image.at<float>(v_ + 1, u_ + 1) * weight_[3];
+}
+
+float InterpolatorBilinear::interpolateFloat(const cv::Mat& image) {
+  return image.at<float>(v_, u_) * weight_[0] +
+         image.at<float>(v_ + 1, u_) * weight_[1] +
+         image.at<float>(v_, u_ + 1) * weight_[2] +
+         image.at<float>(v_ + 1, u_ + 1) * weight_[3];
 }
 
 Color InterpolatorBilinear::interpolateColor(const cv::Mat& color_image) {
@@ -91,7 +104,6 @@ int InterpolatorBilinear::interpolateID(const cv::Mat& id_image) {
                           })
       ->first;
 }
-
 
 void InterpolatorAdaptive::computeWeights(float u, float v,
                                           const Eigen::MatrixXf& range_image) {
@@ -139,13 +151,19 @@ Color InterpolatorAdaptive::interpolateColor(const cv::Mat& color_image) {
   return Color(color_bgr[2], color_bgr[1], color_bgr[0]);
 }
 
-
-
-float InterpolatorAdaptive::interpolateUncertainty(const cv::Mat& uncertainty_image) {
+float InterpolatorAdaptive::interpolateUncertainty(
+    const cv::Mat& uncertainty_image) {
   if (use_bilinear_) {
     return InterpolatorBilinear::interpolateUncertainty(uncertainty_image);
   }
-  return uncertainty_image.at<float>(v_,u_);
+  return uncertainty_image.at<float>(v_, u_);
+}
+
+float InterpolatorAdaptive::interpolateFloat(const cv::Mat& image) {
+  if (use_bilinear_) {
+    return InterpolatorBilinear::interpolateFloat(image);
+  }
+  return image.at<float>(v_, u_);
 }
 
 int InterpolatorAdaptive::interpolateID(const cv::Mat& id_image) {

--- a/panoptic_mapping/src/integration/projective_tsdf_integrator.cpp
+++ b/panoptic_mapping/src/integration/projective_tsdf_integrator.cpp
@@ -165,7 +165,7 @@ bool ProjectiveIntegrator::updateVoxel(
     InterpolatorBase* interpolator, TsdfVoxel* voxel, const Point& p_C,
     const InputData& input, const int submap_id,
     const bool is_free_space_submap, const float truncation_distance,
-    const float voxel_size, ClassVoxel* class_voxel) const {
+    const float voxel_size, ClassVoxel* class_voxel, ScoreVoxel* score_voxel) const {
   // Compute the signed distance. This also sets up the interpolator.
   float sdf;
   if (!computeSignedDistance(p_C, interpolator, &sdf)) {

--- a/panoptic_mapping/src/integration/projective_tsdf_integrator.cpp
+++ b/panoptic_mapping/src/integration/projective_tsdf_integrator.cpp
@@ -312,6 +312,9 @@ void ProjectiveIntegrator::allocateNewBlocks(SubmapCollection* submaps,
           // layer but was added here for simplicity.
           submap->getClassLayerPtr()->allocateBlockPtrByIndex(block_index);
         }
+        if (submap->hasScoreLayer()) {
+          submap->getScoreLayerPtr()->allocateBlockPtrByIndex(block_index);
+        }
 
         // If required, check whether the point is on the boudnary of a block
         // and allocate the neighboring blocks.
@@ -330,6 +333,10 @@ void ProjectiveIntegrator::allocateNewBlocks(SubmapCollection* submaps,
                       neighbor_index);
               if (submap->hasClassLayer()) {
                 submap->getClassLayerPtr()->allocateBlockPtrByIndex(
+                    neighbor_index);
+              }
+              if (submap->hasScoreLayer()) {
+                submap->getScoreLayerPtr()->allocateBlockPtrByIndex(
                     neighbor_index);
               }
             }

--- a/panoptic_mapping/src/integration/single_tsdf_integrator.cpp
+++ b/panoptic_mapping/src/integration/single_tsdf_integrator.cpp
@@ -30,6 +30,7 @@ void SingleTsdfIntegrator::Config::setupParamsAndPrinting() {
   setupParam("verbosity", &verbosity);
   setupParam("projective_integrator", &projective_integrator);
   setupParam("use_color", &use_color);
+  setupParam("use_score", &use_score);
   setupParam("use_segmentation", &use_segmentation);
   setupParam("use_uncertainty", &use_uncertainty);
   setupParam("uncertainty_decay_rate", &uncertainty_decay_rate);
@@ -53,7 +54,7 @@ SingleTsdfIntegrator::SingleTsdfIntegrator(const Config& config,
   if (config_.use_segmentation) {
     addRequiredInputs({InputData::InputType::kSegmentationImage});
   }
-  if (config_.use_uncertainty) {
+  if (config_.use_uncertainty || config_.use_score) {
     addRequiredInputs({InputData::InputType::kUncertaintyImage});
   }
 }
@@ -145,6 +146,10 @@ void SingleTsdfIntegrator::updateBlock(Submap* submap,
   ClassBlock::Ptr class_block;
   const bool use_class_layer =
       submap->hasClassLayer() && config_.use_segmentation;
+  ScoreBlock::Ptr score_block;
+  const bool use_score_layer =
+      submap->hasScoreLayer() && config_.use_score;
+
   if (use_class_layer) {
     if (!submap->getClassLayer().hasBlock(block_index)) {
       LOG_IF(WARNING, config_.verbosity >= 1)
@@ -155,6 +160,16 @@ void SingleTsdfIntegrator::updateBlock(Submap* submap,
     }
     class_block = submap->getClassLayerPtr()->getBlockPtrByIndex(block_index);
   }
+  if (use_score_layer) {
+    if (!submap->getScoreLayer().hasBlock(block_index)) {
+      LOG_IF(WARNING, config_.verbosity >= 1)
+          << "Tried to access inexistent score block '"
+          << block_index.transpose() << "' in submap " << submap->getID()
+          << ".";
+      return;
+    }
+    score_block = submap->getScoreLayerPtr()->getBlockPtrByIndex(block_index);
+  }
 
   // Update all voxels.
   for (size_t i = 0; i < block.num_voxels(); ++i) {
@@ -163,10 +178,14 @@ void SingleTsdfIntegrator::updateBlock(Submap* submap,
     if (use_class_layer) {
       class_voxel = &class_block->getVoxelByLinearIndex(i);
     }
+    ScoreVoxel* score_voxel = nullptr;
+    if (use_score_layer) {
+      score_voxel = &score_block->getVoxelByLinearIndex(i);
+    }
     const Point p_C = T_C_S * block.computeCoordinatesFromLinearIndex(
                                   i);  // Voxel center in camera frame.
     if (updateVoxel(interpolator, &voxel, p_C, input, submap_id, true,
-                    truncation_distance, voxel_size, class_voxel)) {
+                    truncation_distance, voxel_size, class_voxel, score_voxel)) {
       was_updated = true;
     }
   }
@@ -180,7 +199,7 @@ bool SingleTsdfIntegrator::updateVoxel(
     InterpolatorBase* interpolator, TsdfVoxel* voxel, const Point& p_C,
     const InputData& input, const int submap_id,
     const bool is_free_space_submap, const float truncation_distance,
-    const float voxel_size, ClassVoxel* class_voxel) const {
+    const float voxel_size, ClassVoxel* class_voxel, ScoreVoxel* score_voxel) const {
   // Compute the signed distance. This also sets up the interpolator.
   float sdf;
   if (!computeSignedDistance(p_C, interpolator, &sdf)) {
@@ -212,6 +231,10 @@ bool SingleTsdfIntegrator::updateVoxel(
         updateClassVoxel(interpolator, input, class_voxel);
       }
     }
+    // Update the score information if requested.
+    if (score_voxel) {
+        updateScoreVoxel(interpolator, input, score_voxel);
+    }
   } else {
     updateVoxelValues(voxel, sdf, weight);
   }
@@ -225,6 +248,13 @@ void SingleTsdfIntegrator::updateClassVoxel(InterpolatorBase* interpolator,
   // directly.
   const int id = interpolator->interpolateID(input.idImage());
   class_voxel->incrementCount(id);
+}
+
+void SingleTsdfIntegrator::updateScoreVoxel(InterpolatorBase* interpolator,
+                                            const InputData& input,
+                                            ScoreVoxel* score_voxel) const {
+  const float value = interpolator->interpolateFloat(input.uncertaintyImage());
+  score_voxel->addMeasurement(value);
 }
 
 void SingleTsdfIntegrator::updateUncertaintyVoxel(

--- a/panoptic_mapping/src/integration/single_tsdf_integrator.cpp
+++ b/panoptic_mapping/src/integration/single_tsdf_integrator.cpp
@@ -324,6 +324,9 @@ void SingleTsdfIntegrator::allocateNewBlocks(Submap* map, InputData* input) {
           if (map->hasClassLayer()) {
             map->getClassLayerPtr()->allocateBlockPtrByCoordinates(candidate_S);
           }
+          if (map->hasScoreLayer()) {
+            map->getScoreLayerPtr()->allocateBlockPtrByCoordinates(candidate_S);
+          }
         }
       }
     }

--- a/panoptic_mapping/src/map/scores/average.cpp
+++ b/panoptic_mapping/src/map/scores/average.cpp
@@ -12,7 +12,7 @@ bool AverageScoreVoxel::isObserverd() const { return accumulated_weight != 0; }
 
 float AverageScoreVoxel::getScore() const {
   if (!isObserverd()) {
-    LOG(WARNING) << "Getting score of unabserved voxel";
+    LOG(WARNING) << "Getting score of unobserved voxel";
   }
   return average_score;
 }
@@ -37,14 +37,18 @@ bool AverageScoreVoxel::mergeVoxel(const ScoreVoxel& other) {
 }
 
 std::vector<uint32_t> AverageScoreVoxel::serializeVoxelToInt() const {
-  std::vector<uint32_t> result(2u);
-  result.push_back(int32FromX32<float>(accumulated_weight));
-  result.push_back(int32FromX32<float>(average_score));
-  return result;
+  return {int32FromX32<float>(accumulated_weight),
+          int32FromX32<float>(average_score)};
 }
 
 bool AverageScoreVoxel::deseriliazeVoxelFromInt(
     const std::vector<uint32_t>& data, size_t* data_index) {
+  if (*data_index >= data.size()) {
+    LOG(WARNING)
+        << "Can not deserialize voxel from integer data: Out of range (index: "
+        << *data_index << ", data: " << data.size() << ")";
+    return false;
+  }
   accumulated_weight = x32FromInt32<float>(data[*data_index]);
   average_score = x32FromInt32<float>(data[*data_index + 1]);
   *data_index += 2;

--- a/panoptic_mapping/src/map/scores/average.cpp
+++ b/panoptic_mapping/src/map/scores/average.cpp
@@ -9,7 +9,14 @@ ScoreVoxelType AverageScoreVoxel::getVoxelType() const {
 }
 
 bool AverageScoreVoxel::isObserverd() const { return accumulated_weight != 0; }
-float AverageScoreVoxel::getScore() const { return average_score; }
+
+float AverageScoreVoxel::getScore() const {
+  if (!isObserverd()) {
+    LOG(WARNING) << "Getting score of unabserved voxel";
+  }
+  return average_score;
+}
+
 void AverageScoreVoxel::addMeasurement(const float score, const float weight) {
   const float new_weight = accumulated_weight + weight;
   average_score = weight * score / new_weight +

--- a/panoptic_mapping/src/map/scores/average.cpp
+++ b/panoptic_mapping/src/map/scores/average.cpp
@@ -1,0 +1,74 @@
+#include "panoptic_mapping/map/scores/average.h"
+
+#include <vector>
+
+namespace panoptic_mapping {
+
+ScoreVoxelType AverageScoreVoxel::getVoxelType() const {
+  return ScoreVoxelType::kAverage;
+}
+
+bool AverageScoreVoxel::isObserverd() const { return accumulated_weight != 0; }
+float AverageScoreVoxel::getScore() const { return average_score; }
+void AverageScoreVoxel::addMeasurement(const float score, const float weight) {
+  const float new_weight = accumulated_weight + weight;
+  average_score = weight * score / new_weight +
+                  accumulated_weight * average_score / new_weight;
+  accumulated_weight = new_weight;
+}
+
+bool AverageScoreVoxel::mergeVoxel(const ScoreVoxel& other) {
+  // Check type compatibility.
+  auto voxel = dynamic_cast<const AverageScoreVoxel*>(&other);
+  if (!voxel) {
+    LOG(WARNING) << "Can not merge voxels that are not of same type "
+                    "(AverageScoreVoxel).";
+    return false;
+  }
+  addMeasurement(voxel->average_score, voxel->accumulated_weight);
+  return true;
+}
+
+std::vector<uint32_t> AverageScoreVoxel::serializeVoxelToInt() const {
+  std::vector<uint32_t> result(2u);
+  result.push_back(int32FromX32<float>(accumulated_weight));
+  result.push_back(int32FromX32<float>(average_score));
+  return result;
+}
+
+bool AverageScoreVoxel::deseriliazeVoxelFromInt(
+    const std::vector<uint32_t>& data, size_t* data_index) {
+  accumulated_weight = x32FromInt32<float>(data[*data_index]);
+  average_score = x32FromInt32<float>(data[*data_index + 1]);
+  *data_index += 2;
+  return true;
+}
+
+config_utilities::Factory::RegistrationRos<ScoreLayer, AverageScoreLayer, float,
+                                           int>
+    AverageScoreLayer::registration_("average");
+
+AverageScoreLayer::AverageScoreLayer(const Config& config,
+                                     const float voxel_size,
+                                     const int voxels_per_side)
+    : config_(config.checkValid()),
+      ScoreLayerImpl(voxel_size, voxels_per_side) {}
+
+ScoreVoxelType AverageScoreLayer::getVoxelType() const {
+  return ScoreVoxelType::kAverage;
+}
+
+std::unique_ptr<ScoreLayer> AverageScoreLayer::clone() const {
+  return std::make_unique<AverageScoreLayer>(*this);
+}
+
+std::unique_ptr<ScoreLayer> AverageScoreLayer::loadFromStream(
+    const SubmapProto& submap_proto, std::istream* /* proto_file_ptr */,
+    uint64_t* /* tmp_byte_offset_ptr */) {
+  // Nothing special needed to configure for binary counts.
+  return std::make_unique<AverageScoreLayer>(AverageScoreLayer::Config(),
+                                             submap_proto.voxel_size(),
+                                             submap_proto.voxels_per_side());
+}
+
+}  // namespace panoptic_mapping

--- a/panoptic_mapping/src/map/scores/latest.cpp
+++ b/panoptic_mapping/src/map/scores/latest.cpp
@@ -1,0 +1,83 @@
+#include "panoptic_mapping/map/scores/latest.h"
+
+#include <vector>
+
+namespace panoptic_mapping {
+
+ScoreVoxelType LatestScoreVoxel::getVoxelType() const {
+  return ScoreVoxelType::kLatest;
+}
+
+bool LatestScoreVoxel::isObserverd() const { return observed; }
+float LatestScoreVoxel::getScore() const { return latest_score; }
+void LatestScoreVoxel::addMeasurement(const float score, const float weight) {
+  observed = true;
+  latest_score = score;
+}
+
+bool LatestScoreVoxel::mergeVoxel(const ScoreVoxel& other) {
+  // Check type compatibility.
+  auto voxel = dynamic_cast<const LatestScoreVoxel*>(&other);
+  if (!voxel) {
+    LOG(WARNING)
+        << "Can not merge voxels that are not of same type (LatestScoreVoxel).";
+    return false;
+  }
+  // both not observed -> no changes
+  if (!observed && !voxel->observed) {
+    return true;
+  }
+  // both are observed -> we default to this voxel
+  if (observed && voxel->observed) {
+    return true;
+  }
+  // only one is observed, take its value
+  if (voxel->observed) {
+    addMeasurement(voxel->latest_score);
+  }
+  return true;
+}
+
+std::vector<uint32_t> LatestScoreVoxel::serializeVoxelToInt() const {
+  std::vector<uint32_t> result(2u);
+  result.push_back(static_cast<uint32_t>(observed));
+  result.push_back(int32FromX32<float>(latest_score));
+  return result;
+}
+
+bool LatestScoreVoxel::deseriliazeVoxelFromInt(
+    const std::vector<uint32_t>& data, size_t* data_index) {
+  observed = data[*data_index];
+  latest_score = x32FromInt32<float>(data[*data_index + 1]);
+  *data_index += 2;
+  return true;
+}
+
+config_utilities::Factory::RegistrationRos<ScoreLayer, LatestScoreLayer, float,
+                                           int>
+    LatestScoreLayer::registration_("latest");
+
+LatestScoreLayer::LatestScoreLayer(const Config& config,
+                                     const float voxel_size,
+                                     const int voxels_per_side)
+    : config_(config.checkValid()),
+      ScoreLayerImpl(voxel_size, voxels_per_side) {}
+
+ScoreVoxelType LatestScoreLayer::getVoxelType() const {
+  return ScoreVoxelType::kLatest;
+}
+
+std::unique_ptr<ScoreLayer> LatestScoreLayer::clone() const {
+  return std::make_unique<LatestScoreLayer>(*this);
+}
+
+std::unique_ptr<ScoreLayer> LatestScoreLayer::loadFromStream(
+    const SubmapProto& submap_proto, std::istream* /* proto_file_ptr */,
+    uint64_t* /* tmp_byte_offset_ptr */) {
+  // Nothing special needed to configure for binary counts.
+  return std::make_unique<LatestScoreLayer>(LatestScoreLayer::Config(),
+                                             submap_proto.voxel_size(),
+                                             submap_proto.voxels_per_side());
+}
+
+}  // namespace panoptic_mapping

--- a/panoptic_mapping/src/map/submap.cpp
+++ b/panoptic_mapping/src/map/submap.cpp
@@ -91,7 +91,6 @@ void Submap::initialize() {
     has_class_layer_ = true;
   }
   if (config_.useScoreLayer()) {
-    LOG_IF(INFO, config_.verbosity >= 1) << "Using score layer.";
     score_layer_ =
         config_.scores.create(config_.voxel_size, config_.voxels_per_side);
     has_score_layer_ = true;

--- a/panoptic_mapping/src/map/submap.cpp
+++ b/panoptic_mapping/src/map/submap.cpp
@@ -212,6 +212,7 @@ std::unique_ptr<Submap> Submap::loadFromStream(
 
   // Load the submap data.
   submap->has_class_layer_ = submap_proto.num_class_blocks() > 0;
+  submap->has_score_layer_ = submap_proto.num_score_blocks() > 0;
   submap->setInstanceID(submap_proto.instance_id());
   submap->setClassID(submap_proto.class_id());
   submap->setLabel(static_cast<PanopticLabel>(submap_proto.panoptic_label()));
@@ -237,7 +238,7 @@ std::unique_ptr<Submap> Submap::loadFromStream(
   }
 
   // Load the score layer.
-  if (submap_proto.num_class_blocks() > 0) {
+  if (submap_proto.num_score_blocks() > 0) {
     submap->score_layer_ = loadScoreLayerFromStream(
         submap_proto, proto_file_ptr, tmp_byte_offset_ptr);
     if (!submap->score_layer_) {

--- a/panoptic_mapping/src/map/submap.cpp
+++ b/panoptic_mapping/src/map/submap.cpp
@@ -35,10 +35,12 @@ void Submap::Config::initializeDependentVariableDefaults() {
 }
 
 void Submap::Config::setupParamsAndPrinting() {
+  setupParam("verbosity", &verbosity);
   setupParam("voxel_size", &voxel_size);
   setupParam("truncation_distance", &truncation_distance);
   setupParam("voxels_per_side", &voxels_per_side);
   setupParam("classification", &classification, "classification");
+  setupParam("scores", &scores, "scores");
   setupParam("mesh", &mesh, "mesh");
 }
 
@@ -89,8 +91,9 @@ void Submap::initialize() {
     has_class_layer_ = true;
   }
   if (config_.useScoreLayer()) {
-    score_layer_ = config_.scores.create(config_.voxel_size,
-                                                 config_.voxels_per_side);
+    LOG_IF(INFO, config_.verbosity >= 1) << "Using score layer.";
+    score_layer_ =
+        config_.scores.create(config_.voxel_size, config_.voxels_per_side);
     has_score_layer_ = true;
   }
 

--- a/panoptic_mapping/src/map_management/map_manager.cpp
+++ b/panoptic_mapping/src/map_management/map_manager.cpp
@@ -267,6 +267,10 @@ std::string MapManager::pruneBlocks(Submap* submap) const {
   if (submap->hasClassLayer()) {
     class_layer = submap->getClassLayerPtr().get();
   }
+  ScoreLayer* score_layer = nullptr;
+  if (submap->hasScoreLayer()) {
+    score_layer = submap->getScoreLayerPtr().get();
+  }
   TsdfLayer* tsdf_layer = submap->getTsdfLayerPtr().get();
   MeshLayer* mesh_layer = submap->getMeshLayerPtr().get();
   const int voxel_indices = std::pow(submap->getConfig().voxels_per_side, 3);
@@ -305,6 +309,9 @@ std::string MapManager::pruneBlocks(Submap* submap) const {
     if (!has_beloning_voxels) {
       if (class_layer) {
         class_layer->removeBlock(block_index);
+      }
+      if (score_layer) {
+        score_layer->removeBlock(block_index);
       }
       tsdf_layer->removeBlock(block_index);
       mesh_layer->removeMesh(block_index);

--- a/panoptic_mapping/src/tools/serialization.cpp
+++ b/panoptic_mapping/src/tools/serialization.cpp
@@ -175,7 +175,7 @@ bool loadScoreBlocksFromStream(const SubmapProto& submap_proto,
   CHECK_NOTNULL(tmp_byte_offset_ptr);
   CHECK_NOTNULL(layer);
   // Read all blocks and add them to the layer.
-  for (uint32_t block_idx = 0u; block_idx < submap_proto.num_class_blocks();
+  for (uint32_t block_idx = 0u; block_idx < submap_proto.num_score_blocks();
        ++block_idx) {
     voxblox::BlockProto block_proto;
     if (!voxblox::utils::readProtoMsgFromStream(proto_file_ptr, &block_proto,

--- a/panoptic_mapping/test/serialization.cpp
+++ b/panoptic_mapping/test/serialization.cpp
@@ -16,6 +16,8 @@
 #include "panoptic_mapping/map/classification/moving_binary_count.h"
 #include "panoptic_mapping/map/classification/uncertainty.h"
 #include "panoptic_mapping/map/classification/variable_count.h"
+#include "panoptic_mapping/map/scores/average.h"
+#include "panoptic_mapping/map/scores/latest.h"
 #include "panoptic_mapping/test/comparison_utils.h"
 #include "panoptic_mapping/test/randomization_utils.h"
 #include "panoptic_mapping/test/temporary_file.h"
@@ -205,6 +207,22 @@ TEST(Uncertainty, SerializeBlock) {
 
 TEST(Uncertainty, SerializeLayer) {
   testLayerSerialization<UncertaintyVoxel, UncertaintyLayer>();
+}
+
+TEST(AverageScore, SerializeVoxel) {
+  testVoxelSerialization<AverageScoreVoxel>();
+}
+
+TEST(AverageScore, SerializeBlock) {
+  testBlockSerialization<AverageScoreVoxel, AverageScoreLayer>();
+}
+
+TEST(LatestScore, SerializeVoxel) {
+  testVoxelSerialization<LatestScoreVoxel>();
+}
+
+TEST(LatestScore, SerializeBlock) {
+  testBlockSerialization<LatestScoreVoxel, LatestScoreLayer>();
 }
 
 }  // namespace test

--- a/panoptic_mapping_ros/include/panoptic_mapping_ros/visualization/single_tsdf_visualizer.h
+++ b/panoptic_mapping_ros/include/panoptic_mapping_ros/visualization/single_tsdf_visualizer.h
@@ -27,6 +27,9 @@ class SingleTsdfVisualizer : public SubmapVisualizer {
     // Factor which multiplies the entropy value in order to bring it into
     // [0,1] range for visualization.
     float entropy_factor = 1.0f;
+    // Normalisation to bing Score into [0, 1] range
+    float min_score = 0.0f;
+    float max_score = 1.0f;
 
     // Standard visualizer config.
     SubmapVisualizer::Config submap_visualizer;
@@ -54,8 +57,10 @@ class SingleTsdfVisualizer : public SubmapVisualizer {
   void setColorMode(ColorMode color_mode) override;
 
  protected:
-  void colorMeshBlock(const Submap& submap,
-                      voxblox_msgs::MeshBlock* mesh_block);
+  void colorMeshBlockFromClass(const Submap& submap,
+                               voxblox_msgs::MeshBlock* mesh_block);
+  void colorMeshBlockFromScore(const Submap& submap,
+                               voxblox_msgs::MeshBlock* mesh_block);
   std::function<Color(const ClassVoxel&)> getColoring() const;
   void updateVisInfos(const SubmapCollection& submaps) override;
 

--- a/panoptic_mapping_ros/include/panoptic_mapping_ros/visualization/submap_visualizer.h
+++ b/panoptic_mapping_ros/include/panoptic_mapping_ros/visualization/submap_visualizer.h
@@ -59,7 +59,8 @@ class SubmapVisualizer {
     kClassification,
     kUncertainty,
     kEntropy,
-    kPersistent
+    kPersistent,
+    kScore
   };
   enum class VisualizationMode {
     kAll = 0,

--- a/panoptic_mapping_ros/src/visualization/single_tsdf_visualizer.cpp
+++ b/panoptic_mapping_ros/src/visualization/single_tsdf_visualizer.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include <memory>
 #include <utility>
+#include <algorithm>
 #include <vector>
 
 #include "panoptic_mapping/map/classification/fixed_count.h"
@@ -23,6 +24,8 @@ void SingleTsdfVisualizer::Config::setupParamsAndPrinting() {
   setupParam("verbosity", &verbosity);
   setupParam("submap_visualizer", &submap_visualizer);
   setupParam("entropy_factor", &entropy_factor);
+  setupParam("min_score", &min_score);
+  setupParam("max_score", &max_score);
 }
 
 SingleTsdfVisualizer::SingleTsdfVisualizer(const Config& config,
@@ -307,8 +310,11 @@ void SingleTsdfVisualizer::colorMeshBlockFromScore(
         block_edge_length;
     const ScoreVoxel& voxel =
         score_block->getVoxelByCoordinates({mesh_x, mesh_y, mesh_z});
-    const float normalised_value = (voxel.getScore() - config_.min_score) /
+    if (!voxel.isObserverd()) continue;
+    float normalised_value = (voxel.getScore() - config_.min_score) /
                                    (config_.max_score - config_.min_score);
+    normalised_value = std::min(normalised_value, 1.f);
+    normalised_value = std::max(normalised_value, 0.f);
     const Color color = redToGreenGradient(normalised_value);
     mesh_block->r[i] = color.r;
     mesh_block->g[i] = color.g;

--- a/panoptic_mapping_ros/src/visualization/single_tsdf_visualizer.cpp
+++ b/panoptic_mapping_ros/src/visualization/single_tsdf_visualizer.cpp
@@ -125,13 +125,27 @@ std::vector<voxblox_msgs::MultiMesh> SingleTsdfVisualizer::generateMeshMsgs(
 
   // Apply the submap color if necessary.
   if (color_mode_voxblox == voxblox::ColorMode::kGray) {
-    if (!submap.hasClassLayer()) {
-      LOG_IF(WARNING, config_.verbosity >= 2)
-          << "Can not create color for mode '" << colorModeToString(color_mode_)
-          << "' without existing class layer.";
+    if (color_mode_ == ColorMode::kScore) {
+      if (!submap.hasScoreLayer()) {
+        LOG_IF(WARNING, config_.verbosity >= 2)
+            << "Can not create color for mode '"
+            << colorModeToString(color_mode_)
+            << "' without existing score layer.";
+      } else {
+        for (auto& mesh_block : msg.mesh.mesh_blocks) {
+          colorMeshBlockFromScore(submap, &mesh_block);
+        }
+      }
     } else {
-      for (auto& mesh_block : msg.mesh.mesh_blocks) {
-        colorMeshBlock(submap, &mesh_block);
+      if (!submap.hasClassLayer()) {
+        LOG_IF(WARNING, config_.verbosity >= 2)
+            << "Can not create color for mode '"
+            << colorModeToString(color_mode_)
+            << "' without existing class layer.";
+      } else {
+        for (auto& mesh_block : msg.mesh.mesh_blocks) {
+          colorMeshBlockFromClass(submap, &mesh_block);
+        }
       }
     }
   }
@@ -140,8 +154,8 @@ std::vector<voxblox_msgs::MultiMesh> SingleTsdfVisualizer::generateMeshMsgs(
   return result;
 }
 
-void SingleTsdfVisualizer::colorMeshBlock(const Submap& submap,
-                                          voxblox_msgs::MeshBlock* mesh_block) {
+void SingleTsdfVisualizer::colorMeshBlockFromClass(
+    const Submap& submap, voxblox_msgs::MeshBlock* mesh_block) {
   const voxblox::BlockIndex block_index(
       mesh_block->index[0], mesh_block->index[1], mesh_block->index[2]);
   if (!submap.getClassLayer().hasBlock(block_index)) {
@@ -257,6 +271,48 @@ std::function<Color(const ClassVoxel&)> SingleTsdfVisualizer::getColoring()
         // This implies the visualization mode is instances or classes.
         return id_color_map_.colorLookup(voxel.getBelongingID());
       };
+  }
+}
+void SingleTsdfVisualizer::colorMeshBlockFromScore(
+    const Submap& submap, voxblox_msgs::MeshBlock* mesh_block) {
+  const voxblox::BlockIndex block_index(
+      mesh_block->index[0], mesh_block->index[1], mesh_block->index[2]);
+  if (!submap.getScoreLayer().hasBlock(block_index)) {
+    return;
+  }
+
+  // Setup.
+  const ScoreBlock::ConstPtr score_block =
+      submap.getScoreLayer().getBlockConstPtrByIndex(block_index);
+  const float point_conv_factor = 2.f / std::numeric_limits<uint16_t>::max();
+  const float block_edge_length = submap.getScoreLayer().block_size();
+  const size_t num_vertices = mesh_block->x.size();
+  mesh_block->r.resize(num_vertices);
+  mesh_block->g.resize(num_vertices);
+  mesh_block->b.resize(num_vertices);
+
+  for (int i = 0; i < num_vertices; ++i) {
+    // Get the vertex position in map frame.
+    const float mesh_x =
+        (static_cast<float>(mesh_block->x[i]) * point_conv_factor +
+         static_cast<float>(block_index[0])) *
+        block_edge_length;
+    const float mesh_y =
+        (static_cast<float>(mesh_block->y[i]) * point_conv_factor +
+         static_cast<float>(block_index[1])) *
+        block_edge_length;
+    const float mesh_z =
+        (static_cast<float>(mesh_block->z[i]) * point_conv_factor +
+         static_cast<float>(block_index[2])) *
+        block_edge_length;
+    const ScoreVoxel& voxel =
+        score_block->getVoxelByCoordinates({mesh_x, mesh_y, mesh_z});
+    const float normalised_value = (voxel.getScore() - config_.min_score) /
+                                   (config_.max_score - config_.min_score);
+    const Color color = redToGreenGradient(normalised_value);
+    mesh_block->r[i] = color.r;
+    mesh_block->g[i] = color.g;
+    mesh_block->b[i] = color.b;
   }
 }
 

--- a/panoptic_mapping_ros/src/visualization/single_tsdf_visualizer.cpp
+++ b/panoptic_mapping_ros/src/visualization/single_tsdf_visualizer.cpp
@@ -1,9 +1,9 @@
 #include "panoptic_mapping_ros/visualization/single_tsdf_visualizer.h"
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <utility>
-#include <algorithm>
 #include <vector>
 
 #include "panoptic_mapping/map/classification/fixed_count.h"
@@ -312,7 +312,7 @@ void SingleTsdfVisualizer::colorMeshBlockFromScore(
         score_block->getVoxelByCoordinates({mesh_x, mesh_y, mesh_z});
     if (!voxel.isObserverd()) continue;
     float normalised_value = (voxel.getScore() - config_.min_score) /
-                                   (config_.max_score - config_.min_score);
+                             (config_.max_score - config_.min_score);
     normalised_value = std::min(normalised_value, 1.f);
     normalised_value = std::max(normalised_value, 0.f);
     const Color color = redToGreenGradient(normalised_value);

--- a/panoptic_mapping_ros/src/visualization/submap_visualizer.cpp
+++ b/panoptic_mapping_ros/src/visualization/submap_visualizer.cpp
@@ -664,6 +664,8 @@ SubmapVisualizer::ColorMode SubmapVisualizer::colorModeFromString(
     return ColorMode::kPersistent;
   } else if (color_mode == "uncertainty") {
     return ColorMode::kUncertainty;
+  } else if (color_mode == "score") {
+    return ColorMode::kScore;
   } else if (color_mode == "entropy") {
     return ColorMode::kEntropy;
   } else {
@@ -695,6 +697,8 @@ std::string SubmapVisualizer::colorModeToString(ColorMode color_mode) {
       return "entropy";
     case ColorMode::kUncertainty:
       return "uncertainty";
+    case ColorMode::kScore:
+      return "score";
     default:
       return "unknown";
   }


### PR DESCRIPTION
Two options are implemented currently:
- running average of values
- overwriting by keeping the latest value

I focused on the single-tsdf case, not sure if there are more modifications necessary for the multi-tsdf?

If this looks in general good to you, the uncertainty voxel should probably be removed and rather integrated as an exponential decay option in the score layer.