### PR TITLE
Adds a vscode devcontainer for easier development.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ethz-asl/panoptic_mapping:hermann-devel
+FROM ghcr.io/ethz-asl/panoptic_mapping:main
 WORKDIR /catkin_ws/src/
 #RUN catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
 #RUN sudo apt install -y ccache && echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc && source ~/.bashrc && echo $PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/ethz-asl/panoptic_mapping:hermann-devel
+WORKDIR /catkin_ws/src/
+#RUN catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
+#RUN sudo apt install -y ccache && echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc && source ~/.bashrc && echo $PATH
+#RUN ccache --max-size=2G
+#RUN catkin build maplab
+RUN git config --global --add safe.directory /catkin_ws/src/panoptic_mapping
+RUN echo 'source /catkin_ws/devel/setup.bash' | tee -a ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "forwardPorts": [3000],
+  "workspaceFolder": "/catkin_ws/src/panoptic_mapping",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/catkin_ws/src/panoptic_mapping,type=bind"
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,18 @@ Installation instructions for Linux. The repository was developed and tested on 
 <details>
   <summary>Ubuntu 18.04 + ROS Melodic.</summary>
 <p>
-  
+
+
+**Docker**
+To run the panoptic mapper without installation, just use the docker image:
+```bash
+docker pull ghcr.io/ethz-asl/panoptic_mapping:main
+docker run -it ghcr.io/ethz-asl/panoptic_mapping:main bash
+```
+
+For development with vscode, you can just clone this repository and follow the prompts to open it in a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
+
+
 **Prerequisites**
 
 1. If not already done so, install [ROS](http://wiki.ros.org/ROS/Installation) (Desktop-Full is recommended).


### PR DESCRIPTION
Makes it easier for e.g. students to get up and running with a development environment. Just open the folder in vscode and it will automatically detect the settings and suggest to run it in the docker. Depends on the docker PR.